### PR TITLE
Make portable via numem, nurt and nulib (optional)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -2,4 +2,16 @@
     "name": "miniz",
     "description": "Miniz is a library in a single source file that implements the zlib and Deflate compressed data format specification standards.",
     "license": "MIT",
+    "dependencies": {
+        "nulib:stdc": {
+            "version": ">=0.2.0",
+            "optional": true,
+            "default": false
+        },
+        "nurt": {
+            "version": ">=0.1.4",
+            "optional": true,
+            "default": false
+        }
+    }
 }

--- a/source/miniz.d
+++ b/source/miniz.d
@@ -117,10 +117,24 @@ module miniz;
      uses the 64-bit variants: fopen64(), stat64(), etc. Otherwise you won't be able to process large files
      (i.e. 32-bit stat() fails for me on files > 0x7FFFFFFF bytes).
 */
+version(Have_nurt) {
+    import numem.core.hooks : 
+        nu_malloc, nu_realloc, nu_free, 
+        nu_memcpy, nu_memset;
+    import core.internal.exception : onOutOfMemoryError;
 
-import core.stdc.stdlib: malloc, free, realloc;
-import core.stdc.string: memset, memcpy;
-import core.stdc.config: c_long, c_ulong;
+    alias malloc = nu_malloc;
+    alias realloc = nu_realloc;
+    alias free = nu_free;
+    alias memcpy = nu_memcpy;
+    alias memset = nu_memset;
+    alias c_long = int;
+    alias c_ulong = uint;
+} else {
+    import core.stdc.stdlib: malloc, free, realloc;
+    import core.stdc.string: memset, memcpy;
+    import core.stdc.config: c_long, c_ulong;
+}
 
 nothrow @nogc:
 


### PR DESCRIPTION
Companion PR to this: https://github.com/AuburnSounds/intel-intrinsics/pull/148